### PR TITLE
docs: API as sole DB gateway — worker via internal HTTP endpoints

### DIFF
--- a/docs/plans/2026-02-15-postgres-consolidation-design.md
+++ b/docs/plans/2026-02-15-postgres-consolidation-design.md
@@ -301,7 +301,7 @@ Worker behavior: if this returns zero rows, sleep 1 s before retrying to avoid b
 - Deleting a document must first delete its blob object (if present), then delete the `documents` row.
 - A periodic orphan cleanup job can remove MinIO objects with no matching `documents.raw_key`. Frequency and mechanism are implementation details — a daily cron or CLI subcommand is sufficient.
 
-### Worker ↔ API internal endpoints
+### Worker → API internal endpoints
 
 The API is the **sole writer** to Postgres. The worker communicates with the database exclusively through internal HTTP endpoints on the API. This eliminates dual-write complexity, keeps schema migration ownership in one place, and removes `asyncpg`/`pgvector` from the worker's dependency tree.
 
@@ -375,6 +375,7 @@ All internal endpoints require `RAG_API_TOKEN` auth (same as public endpoints).
 |-------|--------|
 | #35 Config & ops | Env vars change — DATABASE_URL replaces 6+ vars |
 | #34 Worker quality | Worker storage layer rewritten — quality work should follow migration |
+| #56 Worker DB gateway | Worker uses API `/internal/*` endpoints; direct DB client (`worker/src/db.py`) is deleted |
 | #45 Chat Phase A | Should build on Postgres, not Qdrant |
 | #42 Extension Phase 3 | `POST /items` becomes `SELECT * FROM documents` |
 | #44 Extension Phase 5 | Reads tier2/tier3 from chunks table |


### PR DESCRIPTION
## Summary

Architectural change: the API becomes the **sole writer** to Postgres. The worker communicates with the database exclusively through `/internal/*` HTTP endpoints on the API.

This replaces the current dual-write approach where both the Node.js API and the Python worker independently maintain DB connections and execute SQL against the same schema.

## Motivation

- **Single schema owner** — API runs migrations, owns all SQL, no cross-language schema drift
- **Simplified worker** — drops `asyncpg`/`pgvector` deps, becomes a stateless HTTP client
- **Atomic operations** — `/internal/tasks/:id/result` writes tier2, tier3, entities, relationships, and summary in one transaction (currently 10+ separate DB calls)
- **No dual connection pools** — one `pg` pool in the API vs two pools in two languages

## New internal API endpoints

| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/internal/tasks/claim` | POST | Dequeue next task (SKIP LOCKED in API). Returns task + chunk texts. |
| `/internal/tasks/:id/result` | POST | Submit full enrichment result in one payload. |
| `/internal/tasks/:id/fail` | POST | Report failure. API handles retry/dead-letter. |
| `/internal/tasks/recover-stale` | POST | Reclaim tasks with expired leases. |

## Impact on existing issues

- **#55** (API services): Expanded — needs `/internal/*` route handlers
- **#56** (Worker): Needs reopening — `db.py` replaced with `api_client.py` using `httpx`
- **#58** (Helm chart): Worker deployment needs `API_URL` + `API_TOKEN` instead of `DATABASE_URL`

## Test plan

- [ ] Design doc changes are consistent
- [ ] Issue descriptions updated to reflect new approach