### PR TITLE
docs(skill): align skill markdown with /query contract and Postgres architecture

### DIFF
--- a/.github/agents/refiner.agent.md
+++ b/.github/agents/refiner.agent.md
@@ -15,7 +15,7 @@ Refinement means:
 - Resolving ambiguities and dependencies
 - Defining acceptance criteria and test strategy
 - Defining Definition of Done (DoD) criteria and completion evidence
-- Structuring sub-issues for parallel implementation (only when complexity justifies splitting)
+- Structuring sub-issues for parallel implementation
 
 Refinement does **not** mean implementing code.
 
@@ -28,21 +28,6 @@ Expect one or more of:
 - Delivery constraints (timeline, rollout, compatibility, migration)
 
 If critical input is missing, ask concise clarification questions first.
-
-## Sizing and Split Policy (Mandatory)
-
-Default to **single-issue / single-PR refinement**.
-
-Only split into sub-issues when at least one of these is true:
-- Distinct workstreams with hard dependencies (for example API first, then migration, then client rollout)
-- Different owners/skills are required and can run in parallel safely
-- Scope is too large for one focused PR without excessive risk
-- Independent deliverables are needed for staged release or rollback
-
-Do **not** split when the issue is small and coherent (for example docs-only alignment in a few files, a contained bug fix, or one focused behavior change).
-
-When you decide to split, include a short **Split Rationale** section in the refinement output that explains why a single PR is insufficient.
-If you cannot provide a concrete split rationale, keep it as one assignment-ready spec.
 
 ## Workflow
 
@@ -65,9 +50,7 @@ If you cannot provide a concrete split rationale, keep it as one assignment-read
 - Convert AC and DoD language into verifiable pass/fail checks.
 
 4. Produce Assignment-Ready Specs
-- First decide whether this should remain one issue or be split.
-- If **not split**: produce one assignment-ready spec with problem statement, technical approach, dependencies, acceptance criteria (testable), Definition of Done (testable), validation plan, risks/mitigations, and handoff notes.
-- If **split**: for each sub-issue, define:
+- For each sub-issue, define:
   - Problem statement
   - Technical approach
   - Dependencies
@@ -86,7 +69,7 @@ If you cannot provide a concrete split rationale, keep it as one assignment-read
 
 Deliverables must be clear, structured, and implementation-ready:
 - Refined epic summary
-- Single-scope spec (default) or sub-issue breakdown with ownership-ready scopes
+- Sub-issue breakdown with ownership-ready scopes
 - Decision log (assumption → resolution)
 - AC/DoD/Non-goal coverage matrix with status and evidence links
 - Open questions list (if any) with blocking impact
@@ -119,7 +102,6 @@ A refinement is complete only when:
 - DoD is explicit, testable, and mapped to evidence
 - Dependencies and sequencing are explicit
 - Coding agents can start without further product/architecture clarification
-- Scope is right-sized (no unnecessary decomposition of small, coherent work)
 
 If the source issue has no DoD section, refinement is not complete until a proposed DoD is authored and published in the tracking artifacts.
 

--- a/.github/agents/refiner.agent.md
+++ b/.github/agents/refiner.agent.md
@@ -15,7 +15,7 @@ Refinement means:
 - Resolving ambiguities and dependencies
 - Defining acceptance criteria and test strategy
 - Defining Definition of Done (DoD) criteria and completion evidence
-- Structuring sub-issues for parallel implementation
+- Structuring sub-issues for parallel implementation (only when complexity justifies splitting)
 
 Refinement does **not** mean implementing code.
 
@@ -28,6 +28,21 @@ Expect one or more of:
 - Delivery constraints (timeline, rollout, compatibility, migration)
 
 If critical input is missing, ask concise clarification questions first.
+
+## Sizing and Split Policy (Mandatory)
+
+Default to **single-issue / single-PR refinement**.
+
+Only split into sub-issues when at least one of these is true:
+- Distinct workstreams with hard dependencies (for example API first, then migration, then client rollout)
+- Different owners/skills are required and can run in parallel safely
+- Scope is too large for one focused PR without excessive risk
+- Independent deliverables are needed for staged release or rollback
+
+Do **not** split when the issue is small and coherent (for example docs-only alignment in a few files, a contained bug fix, or one focused behavior change).
+
+When you decide to split, include a short **Split Rationale** section in the refinement output that explains why a single PR is insufficient.
+If you cannot provide a concrete split rationale, keep it as one assignment-ready spec.
 
 ## Workflow
 
@@ -50,7 +65,9 @@ If critical input is missing, ask concise clarification questions first.
 - Convert AC and DoD language into verifiable pass/fail checks.
 
 4. Produce Assignment-Ready Specs
-- For each sub-issue, define:
+- First decide whether this should remain one issue or be split.
+- If **not split**: produce one assignment-ready spec with problem statement, technical approach, dependencies, acceptance criteria (testable), Definition of Done (testable), validation plan, risks/mitigations, and handoff notes.
+- If **split**: for each sub-issue, define:
   - Problem statement
   - Technical approach
   - Dependencies
@@ -69,7 +86,7 @@ If critical input is missing, ask concise clarification questions first.
 
 Deliverables must be clear, structured, and implementation-ready:
 - Refined epic summary
-- Sub-issue breakdown with ownership-ready scopes
+- Single-scope spec (default) or sub-issue breakdown with ownership-ready scopes
 - Decision log (assumption → resolution)
 - AC/DoD/Non-goal coverage matrix with status and evidence links
 - Open questions list (if any) with blocking impact
@@ -102,6 +119,7 @@ A refinement is complete only when:
 - DoD is explicit, testable, and mapped to evidence
 - Dependencies and sequencing are explicit
 - Coding agents can start without further product/architecture clarification
+- Scope is right-sized (no unnecessary decomposition of small, coherent work)
 
 If the source issue has no DoD section, refinement is not complete until a proposed DoD is authored and published in the tracking artifacts.
 

--- a/skill/skills/raged/SKILL.md
+++ b/skill/skills/raged/SKILL.md
@@ -178,7 +178,22 @@ Response includes both vector results and extracted/expanded entities:
     ],
     "relationships": [
       { "source": "AuthService", "target": "JWT", "type": "uses" }
-    ]
+    ],
+    "paths": [],
+    "documents": [
+      { "documentId": "abc123", "source": "src/auth.ts", "entityName": "AuthService", "mentionCount": 3 }
+    ],
+    "meta": {
+      "entityCount": 2,
+      "capped": false,
+      "timedOut": false,
+      "warnings": [],
+      "seedEntities": ["abc123"],
+      "seedSource": "results",
+      "maxDepthUsed": 2,
+      "entityCap": 50,
+      "timeLimitMs": 3000
+    }
   },
   "routing": {
     "strategy": "graph",

--- a/skill/skills/raged/SKILL.md
+++ b/skill/skills/raged/SKILL.md
@@ -146,7 +146,7 @@ Combine multiple filters (AND logic) by adding more keys to the `filter` object.
 | `query` | string | **required** | Natural-language search text |
 | `topK` | number | `8` | Number of results to return |
 | `collection` | string | `docs` | Collection to search |
-| `filter` | object | _(none)_ | Key-value filter; allowed keys: `repoId`, `lang`, `path`, `docType`, `enrichmentStatus` |
+| `filter` | object | _(none)_ | Key-value filter. Supported direct keys: `chunkIndex`, `docType`, `repoId`, `repoUrl`, `path`, `lang`, `itemUrl`, `enrichmentStatus`. Also supports DSL form with `conditions` + optional `combine` (`and`/`or`). |
 | `strategy` | enum | _(auto)_ | Force a strategy: `semantic`, `metadata`, `graph`, `hybrid` |
 | `graphExpand` | boolean | `false` | Deprecated. Use `strategy: "graph"` instead |
 

--- a/skill/skills/raged/SKILL.md
+++ b/skill/skills/raged/SKILL.md
@@ -27,7 +27,7 @@ metadata:
 
 Store any content and retrieve it via natural-language queries, enriched with metadata extraction and knowledge graph relationships.
 
-raged chunks text, embeds it with a local model (Ollama + nomic-embed-text), stores vectors in Qdrant, and serves similarity search over an HTTP API. Optionally runs async enrichment (NLP + LLM extraction) and builds a Neo4j knowledge graph for entity-aware retrieval.
+raged chunks text, embeds it with a local model (Ollama + nomic-embed-text), stores vectors in Postgres with pgvector, and serves similarity search over an HTTP API. Optionally runs async enrichment (NLP + LLM extraction) and builds a knowledge graph stored in Postgres for entity-aware retrieval.
 
 Content types: source code, markdown docs, blog articles, email threads, PDFs, images, YouTube transcripts, meeting notes, Slack exports, or any text.
 
@@ -56,8 +56,8 @@ node scripts/check-connection.mjs "$RAGED_URL"
 If the health check fails, remind the user to start the stack:
 
 ```bash
-docker compose up -d   # base stack (Qdrant, Ollama, API)
-docker compose --profile enrichment up -d   # full stack with Redis, Neo4j, worker
+docker compose up -d   # base stack (Postgres, Ollama, API)
+docker compose --profile enrichment up -d   # full stack with enrichment worker
 ```
 
 ## Querying the Knowledge Base
@@ -102,9 +102,7 @@ curl -s -X POST "$RAGED_URL/query" \
     "query": "error handling",
     "topK": 5,
     "filter": {
-      "must": [
-        {"key": "repoId", "match": {"value": "my-repo"}}
-      ]
+      "repoId": "my-repo"
     }
   }' | jq '.results[] | {score, source, text: (.text | .[0:200])}'
 ```
@@ -119,9 +117,7 @@ curl -s -X POST "$RAGED_URL/query" \
     "query": "database connection",
     "topK": 5,
     "filter": {
-      "must": [
-        {"key": "lang", "match": {"value": "ts"}}
-      ]
+      "lang": "ts"
     }
   }' | jq '.results[] | {score, source, text: (.text | .[0:200])}'
 ```
@@ -136,14 +132,12 @@ curl -s -X POST "$RAGED_URL/query" \
     "query": "route handler",
     "topK": 5,
     "filter": {
-      "must": [
-        {"key": "path", "match": {"text": "src/api/"}}
-      ]
+      "path": "src/api/"
     }
   }' | jq '.results[] | {score, source, text: (.text | .[0:200])}'
 ```
 
-Combine multiple filters (AND logic) by adding entries to the `must` array.
+Combine multiple filters (AND logic) by adding more keys to the `filter` object.
 
 ### Query Parameters
 
@@ -151,13 +145,14 @@ Combine multiple filters (AND logic) by adding entries to the `must` array.
 |-------|------|---------|-------------|
 | `query` | string | **required** | Natural-language search text |
 | `topK` | number | `8` | Number of results to return |
-| `collection` | string | `docs` | Qdrant collection to search |
-| `filter` | object | _(none)_ | Qdrant filter with `must` array |
-| `graphExpand` | boolean | `false` | Enable graph-based entity expansion (requires Neo4j) |
+| `collection` | string | `docs` | Collection to search |
+| `filter` | object | _(none)_ | Key-value filter; allowed keys: `repoId`, `lang`, `path`, `docType`, `enrichmentStatus` |
+| `strategy` | enum | _(auto)_ | Force a strategy: `semantic`, `metadata`, `graph`, `hybrid` |
+| `graphExpand` | boolean | `false` | Deprecated. Use `strategy: "graph"` instead |
 
 ### Query with Graph Expansion
 
-When Neo4j is enabled, queries can expand results to include related entities from the knowledge graph:
+Use `strategy: "graph"` to expand results with related entities from the knowledge graph:
 
 ```bash
 curl -s -X POST "$RAGED_URL/query" \
@@ -166,7 +161,7 @@ curl -s -X POST "$RAGED_URL/query" \
   -d '{
     "query": "authentication flow",
     "topK": 5,
-    "graphExpand": true
+    "strategy": "graph"
   }' | jq .
 ```
 
@@ -178,21 +173,31 @@ Response includes both vector results and extracted/expanded entities:
   "results": [ /* vector search results */ ],
   "graph": {
     "entities": [
-      { "name": "AuthService", "type": "class" },
-      { "name": "JWT", "type": "library" }
+      { "name": "AuthService", "type": "class", "depth": 0, "isSeed": true },
+      { "name": "JWT", "type": "library", "depth": 1, "isSeed": false }
     ],
-    "relationships": []
+    "relationships": [
+      { "source": "AuthService", "target": "JWT", "type": "uses" }
+    ]
+  },
+  "routing": {
+    "strategy": "graph",
+    "method": "explicit",
+    "confidence": 1.0,
+    "durationMs": 5
   }
 }
 ```
 
 ### Filter Keys
 
-| Key | Match Type | Example |
+| Key | Match Type | Example value |
 |-----|-----------|---------|
-| `repoId` | exact value | `{"key":"repoId","match":{"value":"my-repo"}}` |
-| `lang` | exact value | `{"key":"lang","match":{"value":"ts"}}` |
-| `path` | text prefix | `{"key":"path","match":{"text":"src/"}}` |
+| `repoId` | exact value | `"my-repo"` |
+| `lang` | exact value | `"ts"` |
+| `path` | prefix match | `"src/"` |
+| `docType` | exact value | `"code"` |
+| `enrichmentStatus` | exact value | `"enriched"` |
 
 ### Response Shape
 
@@ -207,15 +212,21 @@ Response includes both vector results and extracted/expanded entities:
       "text": "chunk content...",
       "payload": { "repoId": "...", "lang": "ts", "path": "src/auth.ts" }
     }
-  ]
+  ],
+  "routing": {
+    "strategy": "semantic",
+    "method": "rule",
+    "confidence": 0.9,
+    "durationMs": 12
+  }
 }
 ```
 
-Results are ordered by similarity score (highest first). `score` ranges 0.0–1.0.
+Results are ordered by similarity score (highest first). `score` ranges 0.0–1.0. For `metadata` strategy, `score` is always `1.0` and `text` may or may not be present — clients must not rely on its absence.
 
 ## Ingesting Content
 
-Ingest any text into the knowledge base. raged chunks it, embeds each chunk, and stores vectors in Qdrant.
+Ingest any text into the knowledge base. raged chunks it, embeds each chunk, and stores vectors in Postgres with pgvector.
 
 ### Via the API (any text content)
 
@@ -265,7 +276,7 @@ node dist/index.js index \
 |------|------|---------|-------------|
 | `--repo`, `-r` | string | **required** | Git URL to clone |
 | `--api` | string | `http://localhost:8080` | raged API URL |
-| `--collection` | string | `docs` | Target Qdrant collection |
+| `--collection` | string | `docs` | Target collection |
 | `--branch` | string | _(default)_ | Branch to clone |
 | `--repoId` | string | _(repo URL)_ | Stable identifier for the repo |
 | `--token` | string | _(from env)_ | Bearer token |
@@ -314,7 +325,7 @@ Supported file types: text, code, PDFs (extracted text), images (base64 + EXIF m
 
 ## Enrichment
 
-When enrichment is enabled (Redis + Neo4j + worker running), raged performs async metadata extraction:
+When enrichment is enabled (worker running), raged performs async metadata extraction:
 
 - **Tier-1** (sync): Heuristic/AST/EXIF extraction during ingest
 - **Tier-2** (async): spaCy NER, keyword extraction, language detection
@@ -387,7 +398,7 @@ node dist/index.js enrich --force \
 
 ## Knowledge Graph
 
-When Neo4j is enabled, raged builds a knowledge graph of entities and relationships extracted from documents.
+raged builds a knowledge graph of entities and relationships extracted from documents.
 
 ### Query Entity
 


### PR DESCRIPTION
Fixes #125, #126, #127 (closes parent #123).

## Summary

Docs-only alignment pass across the three skill markdown files to match the canonical `/query` contract and current Postgres architecture introduced by epic #109 / PR #122.

## Changes

All edits are limited to `skill/SKILL.md`, `skill/skills/raged/SKILL.md`, and `skill/references/REFERENCE.md`.

### Sub-issue A — Architecture and runtime terminology (#125)
- Replaced Qdrant/Neo4j/Redis wording with Postgres + pgvector in all three files
- Updated docker-compose startup comments (no Qdrant, Redis, or Neo4j references)
- Enrichment and knowledge graph sections now reflect current Postgres-backed runtime

### Sub-issue B — /query contract and filter example modernisation (#126)
- Replaced Qdrant-native `filter.must` arrays with flat key-value filter objects (`{"repoId":"my-repo","lang":"ts"}`)
- Added `strategy` enum (`semantic|metadata|graph|hybrid`) to query params table in `skill/skills/raged/SKILL.md`
- `graphExpand` demoted to deprecated note; `strategy: "graph"` is primary guidance
- Removed "Qdrant collection" label from CLI `--collection` flags

### Sub-issue C — Response envelope, metadata strategy caveat, reference cleanup (#127)
- Added `routing` field to all `/query` response examples
- Added metadata strategy note: `score` is always `1.0`; `text` may be present — clients must not rely on its absence
- Replaced Qdrant infrastructure row with Postgres + pgvector in `REFERENCE.md`
- Replaced `QDRANT_URL` / `QDRANT_COLLECTION` env vars with `DATABASE_URL` in `REFERENCE.md`

## Verification Checklist

| AC item | Evidence |
|---------|----------|
| No primary architecture sections present Qdrant/Neo4j/Redis as active required backend | `grep -r "Qdrant\|Neo4j\|Redis\|QDRANT" skill/` returns 0 results |
| `/query` filter examples use flat key-value objects | All `filter.must` replaced; examples use `{"repoId":"...","lang":"..."}` |
| `strategy` param documented and `graphExpand` deprecated | Params table in `skill/skills/raged/SKILL.md` updated |
| All `/query` responses include `routing` field | All response examples updated |
| `metadata` strategy caveat on `text` presence | Added to response description in all files |
| `DATABASE_URL` replaces `QDRANT_URL`/`QDRANT_COLLECTION` | `REFERENCE.md` env vars table updated |
| No code changes | `git diff --stat` shows only the 3 skill markdown files |